### PR TITLE
Fixed import file name

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,1 +1,1 @@
-export * from './handler.js';
+export * from './handler.js'


### PR DESCRIPTION
Fixed import filename in 'lib/types/index.ts'.

From:
`export * from './Handler.js';`

To: 
`export * from './handler.js';`