### PR TITLE
fix: don't return empty string when session item not found

### DIFF
--- a/src/lib/hooks/sessionHooks.ts
+++ b/src/lib/hooks/sessionHooks.ts
@@ -12,7 +12,12 @@ export async function sessionHooks({event}: {event: EventHandler}) {
 	};
 
 	event.request.getSessionItem = (itemKey: string) => {
-		const item = event.cookies.get(`kinde_${itemKey}`) || '';
+		const item = event.cookies.get(`kinde_${itemKey}`);
+
+		if (!item) {
+			return item;
+		}
+
 		if (/state/.test(itemKey)) {
 			return item; // return raw state
 		}


### PR DESCRIPTION
# Explain your changes

When a session item is not found we're currently returning empty string, which in the TS SDK interprets as a valid value instead of not found.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
