### PR TITLE
fix: prevent users from being logged out when browser session ends

### DIFF
--- a/src/lib/hooks/sessionHooks.ts
+++ b/src/lib/hooks/sessionHooks.ts
@@ -1,6 +1,8 @@
 import type { EventHandler } from "$lib/types/handler.js";
 
 export async function sessionHooks({ event }: { event: EventHandler }) {
+  const TWENTY_NINE_DAYS = 29 * 24 * 60 * 60; // 29 days in seconds
+
   event.request.setSessionItem = async (
     itemKey: string,
     itemValue: unknown,
@@ -16,6 +18,7 @@ export async function sessionHooks({ event }: { event: EventHandler }) {
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         httpOnly: true,
+        maxAge: TWENTY_NINE_DAYS,
       },
     );
   };

--- a/src/lib/hooks/sessionHooks.ts
+++ b/src/lib/hooks/sessionHooks.ts
@@ -1,8 +1,6 @@
 import type { EventHandler } from "$lib/types/handler.js";
 
 export async function sessionHooks({ event }: { event: EventHandler }) {
-  const TWENTY_NINE_DAYS = 29 * 24 * 60 * 60; // 29 days in seconds
-
   event.request.setSessionItem = async (
     itemKey: string,
     itemValue: unknown,
@@ -18,7 +16,7 @@ export async function sessionHooks({ event }: { event: EventHandler }) {
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         httpOnly: true,
-        maxAge: TWENTY_NINE_DAYS,
+        maxAge: 29 * 24 * 60 * 60,
       },
     );
   };

--- a/src/tests/hooks.spec.ts
+++ b/src/tests/hooks.spec.ts
@@ -157,7 +157,6 @@ describe("sessionHooks", () => {
 
   it("should set cookies with 29-day expiry", async () => {
     // Arrange
-    const TWENTY_NINE_DAYS = 29 * 24 * 60 * 60; // 29 days in seconds
     const event = {
       request: {},
       cookies: {
@@ -176,7 +175,7 @@ describe("sessionHooks", () => {
       "kinde_testKey",
       "testValue",
       expect.objectContaining({
-        maxAge: TWENTY_NINE_DAYS,
+        maxAge: 29 * 24 * 60 * 60,
         domain: process.env.KINDE_COOKIE_DOMAIN,
         path: "/",
         secure: process.env.NODE_ENV === "production",

--- a/src/tests/hooks.spec.ts
+++ b/src/tests/hooks.spec.ts
@@ -154,4 +154,35 @@ describe("sessionHooks", () => {
     expect(retrievedValue1).toBeUndefined();
     expect(retrievedValue2).toBeUndefined();
   });
+
+  it("should set cookies with 29-day expiry", async () => {
+    // Arrange
+    const TWENTY_NINE_DAYS = 29 * 24 * 60 * 60; // 29 days in seconds
+    const event = {
+      request: {},
+      cookies: {
+        set: vi.fn(),
+        get: vi.fn(),
+      },
+    };
+
+    await sessionHooks({ event });
+
+    // Act
+    await event.request.setSessionItem("testKey", "testValue");
+
+    // Assert
+    expect(event.cookies.set).toHaveBeenCalledWith(
+      "kinde_testKey",
+      "testValue",
+      expect.objectContaining({
+        maxAge: TWENTY_NINE_DAYS,
+        domain: process.env.KINDE_COOKIE_DOMAIN,
+        path: "/",
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        httpOnly: true,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
Fixed an issue where users were being unexpectedly logged out when closing their browser due to session cookies expiring immediately. Updated the sessionHooks to set cookies with an expiry instead of using session-only cookies.

Modified setSessionItem in src/lib/hooks/sessionHooks.ts to include maxAge
Added test coverage to verify cookies are set with the correct expiry and security options


# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
