### PR TITLE
fix: ensure we await the redirectToPostLoginUrl as it is a promise

### DIFF
--- a/src/lib/handleAuth/handleAuth.ts
+++ b/src/lib/handleAuth/handleAuth.ts
@@ -83,7 +83,7 @@ export async function handleAuth({
         new URL(request.url),
       );
       await redirectToPostLoginUrl();
-      throw redirect(302, kindeConfiguration.loginRedirectURL ?? "/");
+      throw redirect(302, kindeConfiguration.loginRedirectURL || "/");
     case "logout":
       url = await kindeAuthClient.logout(request as unknown as SessionManager);
       break;


### PR DESCRIPTION
# Explain your changes
We needed to await the redirectToPostLoginUrl call as it was updated to be a promise. 

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
