### PR TITLE
feat: create new function to sync own store

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,112 @@ npm run build
    }
    ```
 
+## Client-Side Token Synchronization
+
+When building an API client for a different backend that uses Kinde authentication tokens, you need a way to access the token in the browser. Since `getToken()` is server-side only, the SDK provides client-side token synchronization utilities.
+
+### Using the Default Token Store
+
+The simplest approach is to use the default `tokenStore`:
+
+```typescript
+import { tokenStore } from "@kinde-oss/kinde-auth-sveltekit";
+import { onMount } from "svelte";
+
+// In your component
+onMount(async () => {
+  // Sync the token when the component mounts
+  await tokenStore.sync();
+});
+
+// Use the token in your API client
+$tokenStore; // Current token or null
+```
+
+### Creating a Custom Token Store
+
+You can create your own token store instance:
+
+```typescript
+import { createTokenStore } from "@kinde-oss/kinde-auth-sveltekit";
+
+const myTokenStore = createTokenStore();
+
+// Sync the token
+await myTokenStore.sync();
+
+// Check if syncing is in progress
+$myTokenStore.isSyncing; // boolean
+
+// Access the token
+$myTokenStore; // Current token or null
+```
+
+### Syncing with Your Own Store
+
+If you already have a Svelte store for your API client tokens, you can sync it with the Kinde token:
+
+```typescript
+import { syncTokenWithStore } from "@kinde-oss/kinde-auth-sveltekit";
+import { writable } from "svelte/store";
+
+// Your existing API token store
+const apiTokenStore = writable<string | null>(null);
+
+// Sync it with the Kinde token
+await syncTokenWithStore(apiTokenStore);
+
+// Now your store is in sync
+$apiTokenStore; // Current Kinde token or null
+```
+
+### Example: Using Token in API Client
+
+Here's a complete example of using the token store with an API client:
+
+```typescript
+// lib/apiClient.ts
+import { writable } from "svelte/store";
+import { syncTokenWithStore } from "@kinde-oss/kinde-auth-sveltekit";
+
+const apiToken = writable<string | null>(null);
+
+// Sync token on initialization
+export async function initApiClient() {
+  await syncTokenWithStore(apiToken);
+}
+
+// Make API calls using the token
+export async function fetchFromBackend(endpoint: string) {
+  const token = $apiToken;
+  if (!token) {
+    throw new Error("Not authenticated");
+  }
+
+  const response = await fetch(`https://your-backend.com${endpoint}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  return response.json();
+}
+```
+
+```svelte
+<!-- MyComponent.svelte -->
+<script>
+  import { onMount } from "svelte";
+  import { initApiClient, fetchFromBackend } from "$lib/apiClient";
+
+  onMount(async () => {
+    await initApiClient();
+    const data = await fetchFromBackend("/api/data");
+  });
+</script>
+```
+
 ### How to test
 
 Firstly, you need to install a web browser for testing purposes

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ const myTokenStore = createTokenStore();
 await myTokenStore.sync();
 
 // Check if syncing is in progress
-$myTokenStore.isSyncing; // boolean
+const isSyncing = myTokenStore.isSyncing;
+// In a Svelte component you can then use:
+// $isSyncing; // boolean
 
 // Access the token
 $myTokenStore; // Current token or null
@@ -122,7 +124,7 @@ Here's a complete example of using the token store with an API client:
 
 ```typescript
 // lib/apiClient.ts
-import { writable } from "svelte/store";
+import { writable, get } from "svelte/store";
 import { syncTokenWithStore } from "@kinde-oss/kinde-auth-sveltekit";
 
 const apiToken = writable<string | null>(null);
@@ -134,7 +136,7 @@ export async function initApiClient() {
 
 // Make API calls using the token
 export async function fetchFromBackend(endpoint: string) {
-  const token = $apiToken;
+  const token = get(apiToken);
   if (!token) {
     throw new Error("Not authenticated");
   }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,5 +2,7 @@ export * from "./KindeSDK";
 export * from "./config/index";
 export * from "./handleAuth/index";
 export * from "./hooks/index";
+export * from "./stores/index";
 export * from "./types/index";
+export * from "./utils/index";
 export * from "@kinde-oss/kinde-typescript-sdk";

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,0 +1,1 @@
+export * from "./tokenStore.js";

--- a/src/lib/stores/tokenStore.ts
+++ b/src/lib/stores/tokenStore.ts
@@ -1,0 +1,69 @@
+import { writable, type Writable } from "svelte/store";
+import { browser } from "$app/environment";
+
+export interface TokenStore extends Writable<string | null> {
+  sync: () => Promise<string | null>;
+  isSyncing: Writable<boolean>;
+}
+
+/**
+ * Creates a token store that can be synced with the Kinde session token.
+ * This allows you to keep your own store in sync with the current authentication token.
+ *
+ * @example
+ * ```ts
+ * import { createTokenStore } from '@kinde-oss/kinde-auth-sveltekit';
+ *
+ * const tokenStore = createTokenStore();
+ *
+ * // Sync the token
+ * await tokenStore.sync();
+ *
+ * // Use the token in your API client
+ * $tokenStore // This will be the current token or null
+ * ```
+ */
+export function createTokenStore(): TokenStore {
+  const store = writable<string | null>(null);
+  const isSyncing = writable<boolean>(false);
+
+  const sync = async (): Promise<string | null> => {
+    if (!browser) {
+      console.warn("Token sync can only be called in the browser");
+      return null;
+    }
+
+    isSyncing.set(true);
+    try {
+      const response = await fetch("/api/auth/token");
+      if (!response.ok) {
+        if (response.status === 401) {
+          store.set(null);
+          return null;
+        }
+        throw new Error(`Failed to fetch token: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      store.set(data.token);
+      return data.token;
+    } catch (error) {
+      console.error("Error syncing token:", error);
+      store.set(null);
+      return null;
+    } finally {
+      isSyncing.set(false);
+    }
+  };
+
+  return {
+    ...store,
+    sync,
+    isSyncing,
+  };
+}
+
+/**
+ * Default token store instance. You can use this directly or create your own with createTokenStore().
+ */
+export const tokenStore = createTokenStore();

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,3 +1,5 @@
+export * from "./tokenSync.js";
+
 export const pick = (target: Record<string, unknown>, path: string[]) => {
   return Object.keys(target).reduce(
     (prev, curr) => {

--- a/src/lib/utils/tokenSync.ts
+++ b/src/lib/utils/tokenSync.ts
@@ -1,0 +1,51 @@
+import { browser } from "$app/environment";
+import type { Writable } from "svelte/store";
+
+/**
+ * Syncs the current Kinde access token with a custom Svelte store.
+ * This is useful when you have your own store for API client tokens.
+ *
+ * @param store - A writable Svelte store to sync the token with
+ * @returns The token value (or null if not authenticated)
+ *
+ * @example
+ * ```ts
+ * import { syncTokenWithStore } from '@kinde-oss/kinde-auth-sveltekit';
+ * import { writable } from 'svelte/store';
+ *
+ * const myApiTokenStore = writable<string | null>(null);
+ *
+ * // Sync your store with the Kinde token
+ * await syncTokenWithStore(myApiTokenStore);
+ *
+ * // Now your store is in sync and can be used in API calls
+ * $myApiTokenStore // Current token or null
+ * ```
+ */
+export async function syncTokenWithStore(
+  store: Writable<string | null>,
+): Promise<string | null> {
+  if (!browser) {
+    console.warn("Token sync can only be called in the browser");
+    return null;
+  }
+
+  try {
+    const response = await fetch("/api/auth/token");
+    if (!response.ok) {
+      if (response.status === 401) {
+        store.set(null);
+        return null;
+      }
+      throw new Error(`Failed to fetch token: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    store.set(data.token);
+    return data.token;
+  } catch (error) {
+    console.error("Error syncing token:", error);
+    store.set(null);
+    return null;
+  }
+}

--- a/src/routes/api/auth/token/+server.ts
+++ b/src/routes/api/auth/token/+server.ts
@@ -1,0 +1,15 @@
+import { json, type RequestEvent } from "@sveltejs/kit";
+import type { EventHandler } from "$lib/types/handler.js";
+
+export async function GET(event: RequestEvent) {
+  // Access the session item from the request (set by sessionHooks)
+  // The sessionHooks add getSessionItem to the request object
+  const request = event.request as EventHandler["request"];
+  const accessToken = request.getSessionItem("access_token");
+
+  if (!accessToken) {
+    return json({ token: null }, { status: 401 });
+  }
+
+  return json({ token: accessToken });
+}


### PR DESCRIPTION
# Explain your changes

Fixes [60](https://github.com/kinde-oss/kinde-sveltekit-sdk/issues/60)
 - Adds a browser-only /api/auth/token GET handler that surfaces the session access token (or 401 with token: null) so client-side code can hydrate its own stores without exposing additional data from the session object.
+server.tsLines 1-15
`import { json, type RequestEvent } from "@sveltejs/kit";import type { EventHandler } from "$lib/types/handler.js";export async function GET(event: RequestEvent) {  const request = event.request as EventHandler["request"];  const accessToken = request.getSessionItem("access_token");  if (!accessToken) {    return json({ token: null }, { status: 401 });  }  return json({ token: accessToken });}
`
- Introduces createTokenStore, the shared tokenStore, and the syncTokenWithStore helper so components or custom stores can keep their writable state aligned with Kinde’s token while tracking isSyncing and handling SSR/browser differences consistently.
tokenStore.tsLines 1-70
`export interface TokenStore extends Writable<string | null> {  sync: () => Promise<string | null>;  isSyncing: Writable<boolean>;}...export const tokenStore = createTokenStore();
`
tokenSync.tsLines 1-52
`export async function syncTokenWithStore(  store: Writable<string | null>,): Promise<string | null> {  if (!browser) {    console.warn("Token sync can only be called in the browser");    return null;  }  ...  store.set(data.token);  return data.token;}
`


# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
