### PR TITLE
Add invitation code handling and tests for hooks.server

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,21 @@
 import { sessionHooks, type Handler } from "$lib/index.js";
+import { redirect } from "@sveltejs/kit";
+
+const AUTH_API_PREFIX = "/api/auth/";
 
 export const handle: Handler = async ({ event, resolve }) => {
+  const invitationCode = event.url.searchParams.get("invitation_code")?.trim();
+  const isAuthRoute = event.url.pathname.startsWith(AUTH_API_PREFIX);
+
+  if (invitationCode && !isAuthRoute) {
+    const params = new URLSearchParams({
+      invitation_code: invitationCode,
+      is_invitation: "true",
+    });
+
+    throw redirect(302, `${AUTH_API_PREFIX}register?${params.toString()}`);
+  }
+
   sessionHooks({ event });
 
   return await resolve(event);

--- a/src/tests/hooksServer.spec.ts
+++ b/src/tests/hooksServer.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { sessionHooksMock } = vi.hoisted(() => ({
+  sessionHooksMock: vi.fn(),
+}));
+
+vi.mock("$lib/index.js", () => ({
+  sessionHooks: sessionHooksMock,
+}));
+
+import { handle } from "../hooks.server";
+
+type RedirectLikeError = {
+  status: number;
+  location: string;
+};
+
+describe("hooks.server handle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects to invite register auth flow when invitation_code is present", async () => {
+    const resolve = vi.fn();
+
+    try {
+      await handle({
+        event: {
+          url: new URL("http://localhost:4173/?invitation_code=inv_123"),
+        },
+        resolve,
+      } as never);
+    } catch (error: unknown) {
+      const redirectError = error as RedirectLikeError;
+      expect(redirectError.status).toBe(302);
+      expect(redirectError.location).toBe(
+        "/api/auth/register?invitation_code=inv_123&is_invitation=true",
+      );
+    }
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(sessionHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect for auth api routes", async () => {
+    const resolve = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const response = await handle({
+      event: {
+        url: new URL(
+          "http://localhost:4173/api/auth/register?invitation_code=inv_123",
+        ),
+      },
+      resolve,
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(sessionHooksMock).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores empty invitation_code", async () => {
+    const resolve = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const response = await handle({
+      event: {
+        url: new URL("http://localhost:4173/?invitation_code=   "),
+      },
+      resolve,
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(sessionHooksMock).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/hooksServer.spec.ts
+++ b/src/tests/hooksServer.spec.ts
@@ -10,11 +10,6 @@ vi.mock("$lib/index.js", () => ({
 
 import { handle } from "../hooks.server";
 
-type RedirectLikeError = {
-  status: number;
-  location: string;
-};
-
 describe("hooks.server handle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -23,20 +18,17 @@ describe("hooks.server handle", () => {
   it("redirects to invite register auth flow when invitation_code is present", async () => {
     const resolve = vi.fn();
 
-    try {
-      await handle({
+    await expect(
+      handle({
         event: {
           url: new URL("http://localhost:4173/?invitation_code=inv_123"),
         },
         resolve,
-      } as never);
-    } catch (error: unknown) {
-      const redirectError = error as RedirectLikeError;
-      expect(redirectError.status).toBe(302);
-      expect(redirectError.location).toBe(
-        "/api/auth/register?invitation_code=inv_123&is_invitation=true",
-      );
-    }
+      } as never),
+    ).rejects.toMatchObject({
+      status: 302,
+      location: "/api/auth/register?invitation_code=inv_123&is_invitation=true",
+    });
 
     expect(resolve).not.toHaveBeenCalled();
     expect(sessionHooksMock).not.toHaveBeenCalled();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vitest/config";
-import path from "path";
 
 export default defineConfig({
   plugins: [sveltekit()],


### PR DESCRIPTION
Implement invitation code handling in the server hooks to redirect users to the registration flow when an invitation code is present. Include tests to verify the redirection behavior and ensure proper handling of invitation codes. 

In `vite.config.ts` I removed unused import to fully clean lint. 🧹 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._

