### PR TITLE
chore(ci): run build and test on Node.js 22

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Summary
- Bump the GitHub Actions Node matrix from `20.x` to `22.x`
- Unblocks dependency updates that require Node 22+ (for example pnpm 11)

## Test plan
- [x] Locally verified on Node 22 with current pnpm 10: `pnpm install`, `pnpm lint`, `pnpm build`, `pnpm test:coverage`
- [x] Confirm CI `main (22.x)` passes on this PR
