### PR TITLE
chore: enforce dependency release-age cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended", ":rebaseStalePrs"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
Standardizes this repo's Renovate config on the org baseline: `config:recommended` + `:rebaseStalePrs`, plus `minimumReleaseAge` (7d) and `internalChecksFilter: strict` so Renovate holds a dependency update until its release is at least 7 days old. Note: this replaces the repo's previous Renovate config; only the Renovate config file is changed.